### PR TITLE
Stop using deprecated increment/decrement operators

### DIFF
--- a/Sources/TCPServer.swift
+++ b/Sources/TCPServer.swift
@@ -65,7 +65,7 @@ struct TCPServer: TCPServerType {
                         }
                     } catch {
                         completion({ throw error })
-                        ++errorCount
+                        errorCount += 1
                         if errorCount == maxErrors {
                             self.stop()
                             break

--- a/Sources/TCPStream.swift
+++ b/Sources/TCPStream.swift
@@ -93,7 +93,7 @@ final class TCPStream: StreamType {
             } catch TCPError.ClosedSocket {
                 break
             } catch {
-                ++sequentialErrorsCount
+                sequentialErrorsCount += 1
                 if sequentialErrorsCount >= 10 {
                     completion({ throw error })
                 }


### PR DESCRIPTION
Recent Swift compiler snapshots emit deprecation warnings for this.
