### PR TITLE
HTTP Fixes

### DIFF
--- a/Modules/HTTP/Sources/HTTP/Parser/RequestParser.swift
+++ b/Modules/HTTP/Sources/HTTP/Parser/RequestParser.swift
@@ -44,7 +44,7 @@ public final class RequestParser {
         self.stream = stream
         self.buffer = Data(count: bufferSize)
         self.context = RequestContext.allocate(capacity: 1)
-        self.context.initialize(to: RequestParserContext { request in
+        self.context.initialize(to: RequestParserContext { [unowned self] request in
             self.requests.insert(request, at: 0)
         })
 

--- a/Modules/HTTP/Sources/HTTP/Parser/ResponseParser.swift
+++ b/Modules/HTTP/Sources/HTTP/Parser/ResponseParser.swift
@@ -45,7 +45,7 @@ public final class ResponseParser {
         self.stream = stream
         self.buffer = Data(count: bufferSize)
         self.context = ResponseContext.allocate(capacity: 1)
-        self.context.initialize(to: ResponseParserContext { response in
+        self.context.initialize(to: ResponseParserContext { [unowned self] response in
             self.responses.insert(response, at: 0)
         })
 


### PR DESCRIPTION
# Summary

Fixes two strong ref's inside closures that prevent Request/Response parsers from ever being dealloc'd
