### PR TITLE
Fix StandardOutputAppender init not accessible outside the module

### DIFF
--- a/Modules/Core/Sources/Core/Log/StandardOutputAppender.swift
+++ b/Modules/Core/Sources/Core/Log/StandardOutputAppender.swift
@@ -3,7 +3,7 @@ public class StandardOutputAppender : Appender {
     public var levels: Logger.Level
     var lastMessage: String = ""
 
-    init(name: String = "Standard Output Appender", levels: Logger.Level = .all) {
+    public init(name: String = "Standard Output Appender", levels: Logger.Level = .all) {
         self.name = name
         self.levels = levels
     }


### PR DESCRIPTION
StandardOutputAppender was not accessible outside the module, thus couldn't be instantiated like this:

`var logger = Logger(name: "main", appenders: [StandardOutputAppender(levels: .info)])`
