### PR TITLE
Venice/Ticker produces Double instead of Void

### DIFF
--- a/Modules/Venice/Sources/Venice/Ticker/Ticker.swift
+++ b/Modules/Venice/Sources/Venice/Ticker/Ticker.swift
@@ -1,8 +1,8 @@
 public final class Ticker {
-    private let internalChannel = Channel<Void>()
+    private let internalChannel = Channel<Double>()
     private var stopped: Bool = false
 
-    public var channel: ReceivingChannel<Void> {
+    public var channel: ReceivingChannel<Double> {
         return internalChannel.receivingChannel
     }
 
@@ -11,7 +11,7 @@ public final class Ticker {
             while true {
                 nap(for: period)
                 if self.stopped { break }
-                self.internalChannel.send(Void())
+                self.internalChannel.send(now())
             }
         }
     }

--- a/Modules/Venice/Tests/VeniceTests/Venice/TickerTests.swift
+++ b/Modules/Venice/Tests/VeniceTests/Venice/TickerTests.swift
@@ -3,11 +3,16 @@ import XCTest
 
 public class TickerTests : XCTestCase {
     func testTicker() {
-        let ticker = Ticker(period: 10.milliseconds)
+        let tickerPeriod = 20.milliseconds
+        let ticker = Ticker(period: tickerPeriod)
         co {
-            for _ in ticker.channel {}
+            var last: Double = ticker.channel.receive()!
+            for time in ticker.channel {
+                XCTAssertEqualWithAccuracy(time - last, tickerPeriod, accuracy: tickerPeriod / 2)
+                last = time
+            }
         }
-        nap(for: 100.milliseconds)
+        nap(for: 200.milliseconds)
         ticker.stop()
         nap(for: 20.milliseconds)
     }


### PR DESCRIPTION
Hi, it looks like this small feature from a previous PR was accidentally reverted during a larger refactoring. 

Here it is resubmitted.
Regards
