### PR TITLE
Fix: increase time tolerance for VeniceTests/TickerTests

### DIFF
--- a/Modules/Venice/Tests/VeniceTests/Venice/TickerTests.swift
+++ b/Modules/Venice/Tests/VeniceTests/Venice/TickerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 public class TickerTests : XCTestCase {
     func testTicker() {
-        let tickerPeriod = 20.milliseconds
+        let tickerPeriod = 50.milliseconds
         let ticker = Ticker(period: tickerPeriod)
         co {
             var last: Double = ticker.channel.receive()!
@@ -12,7 +12,7 @@ public class TickerTests : XCTestCase {
                 last = time
             }
         }
-        nap(for: 200.milliseconds)
+        nap(for: 300.milliseconds)
         ticker.stop()
         nap(for: 20.milliseconds)
     }


### PR DESCRIPTION
Since the PR on Ticker https://github.com/Zewo/Zewo/pull/158 (merged today), the TickerTests has a time tolerance (20 msec +/- 10 msec) that is sometimes too small for macOS on Travis (at least the XCode part of the tests). The test sometimes fail because ticking happens right after the tolerance. 

For instance https://travis-ci.org/Zewo/Zewo/jobs/162709558 yields

```
/Users/travis/build/Zewo/Zewo/Tests/VeniceTests/Venice/TickerTests.swift:11: error: -[VeniceTests.TickerTests testTicker] : 
XCTAssertEqualWithAccuracy failed: ("0.0301818980000235") is not equal to ("0.02") +/- ("0.01") - 
```

This PR fixes the problem by increasing the timings and tolerance a bit (to 50 msec +/- 25 msec). At least they have now passed multiple times on Travis.

The tests may still fail on Linux for another reason (hang after all tests succeed).
