### PR TITLE
Bugfixes

### DIFF
--- a/Modules/Core/Sources/Core/Buffer/Buffer.swift
+++ b/Modules/Core/Sources/Core/Buffer/Buffer.swift
@@ -162,6 +162,9 @@ extension Buffer {
     
     public init(count: Int, fill: (UnsafeMutableBufferPointer<Byte>) throws -> Void) rethrows {
         self = try Buffer(capacity: count) {
+            guard count > 0 else {
+                return 0
+            }
             try fill($0)
             return count
         }

--- a/Modules/Core/Tests/CoreTests/Map/MapTests.swift
+++ b/Modules/Core/Tests/CoreTests/Map/MapTests.swift
@@ -793,12 +793,12 @@ public class MapTests : XCTestCase {
         XCTAssertThrowsError(try fuuOptional.asMap())
         XCTAssertEqual(try [1969].asMap(), [1969])
         let fuuArray: [Baz] = []
-        XCTAssertThrowsError(try fuuArray.asMap())
+        XCTAssertEqual(try fuuArray.asMap(), [])
         XCTAssertEqual(try ["foo": 1969].asMap(), ["foo": 1969])
         let fuuDictionaryA: [Int: Foo] = [:]
         XCTAssertThrowsError(try fuuDictionaryA.asMap())
         let fuuDictionaryB: [String: Baz] = [:]
-        XCTAssertThrowsError(try fuuDictionaryB.asMap())
+        XCTAssertEqual(try fuuDictionaryB.asMap(), [:])
     }
 }
 

--- a/Modules/HTTP/Sources/HTTP/Message/Headers.swift
+++ b/Modules/HTTP/Sources/HTTP/Message/Headers.swift
@@ -38,16 +38,22 @@ extension Headers : Sequence {
 
         set(header) {
             headers[field] = header
+            
+            if field == "Content-Length" && header != nil && headers["Transfer-Encoding"] == "chunked" {
+                headers["Transfer-Encoding"] = nil
+            } else if field == "Transfer-Encoding" && header == "chunked" {
+                headers["Content-Length"] = nil
+            }
         }
     }
 
     public subscript(field: CaseInsensitiveStringRepresentable) -> String? {
         get {
-            return headers[field.caseInsensitiveString]
+            return self[field.caseInsensitiveString]
         }
 
         set(header) {
-            headers[field.caseInsensitiveString] = header
+            self[field.caseInsensitiveString] = header
         }
     }
 }

--- a/Modules/HTTP/Sources/HTTP/Serializer/BodyStream.swift
+++ b/Modules/HTTP/Sources/HTTP/Serializer/BodyStream.swift
@@ -31,11 +31,10 @@ final class BodyStream : Stream {
             throw StreamError.closedStream
         }
         
-        let newLine: [Byte] = [13, 10]
         try transport.write(String(buffer.count, radix: 16), deadline: deadline)
-        try transport.write(newLine, deadline: deadline)
+        try transport.write("\r\n", deadline: deadline)
         try transport.write(buffer, deadline: deadline)
-        try transport.write(newLine, deadline: deadline)
+        try transport.write("\r\n", deadline: deadline)
     }
 
     func flush(deadline: Double) throws {

--- a/Modules/TCP/Sources/TCP/TCPStream.swift
+++ b/Modules/TCP/Sources/TCP/TCPStream.swift
@@ -37,9 +37,9 @@ public final class TCPStream : Stream {
         }
         
         let bytesWritten = tcpsend(socket, buffer.baseAddress!, buffer.count, deadline.int64milliseconds)
-        try ensureLastOperationSucceeded()
         
         guard bytesWritten == buffer.count else {
+            try ensureLastOperationSucceeded()
             throw SystemError.other(errorNumber: -1)
         }
     }


### PR DESCRIPTION
A few small bug fixes / nits:
- Body Stream to use "\r\n" rather than newline UInt8's (it's faster, don't ask me why)
- Ensure that if transfer-encoding=chunked content-length is removed and vice versa if content-length is set and transfer-encoding=chunked remove transfer-encoding
- Add a bounds check on `Buffer`
- Checks for errors on tcp stream `write` ONLY if the bytes written is not equal to the bytes given
- Adds a bounds check on `Stream` reads
- Adds a method to read an exact amount of bytes from a `Stream`
- Adds a slow path for `try asMap()` for Dictionaries/Arrays they will encode one by one if the Element type can't be inferred properly.
