### PR TITLE
Fix SHA1 hash calculation when accepting a websocket connection

### DIFF
--- a/Modules/WebSocket/Sources/WebSocket/SHA1.swift
+++ b/Modules/WebSocket/Sources/WebSocket/SHA1.swift
@@ -34,20 +34,20 @@ func reverseBytes(_ value: UInt32) -> UInt32 {
 
 func arrayOfBytes<T>(_ value: T, length: Int? = nil) -> [UInt8] {
     let totalBytes = length ?? MemoryLayout<T>.size
-
+    
     let valuePointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
     valuePointer.pointee = value
-    defer {
-        valuePointer.deinitialize()
-        valuePointer.deallocate(capacity: 1)
+    
+    let bytesPointer = UnsafeMutablePointer<UInt8>(OpaquePointer(valuePointer))
+    var bytes = Array<UInt8>(repeating: 0, count: totalBytes)
+    for j in 0..<min(MemoryLayout<T>.size,totalBytes) {
+        bytes[totalBytes - 1 - j] = (bytesPointer + j).pointee
     }
-
-    return valuePointer.withMemoryRebound(to: UInt8.self, capacity: totalBytes) { bytes in
-        for i in 0..<min(MemoryLayout<T>.size, totalBytes) {
-            bytes[totalBytes - 1 - i] = (bytes + i).pointee
-        }
-        return Array(UnsafeBufferPointer(start: bytes, count: totalBytes))
-    }
+    
+    valuePointer.deinitialize()
+    valuePointer.deallocate(capacity: 1)
+    
+    return bytes
 }
 
 func toUInt32Array(_ slice: ArraySlice<UInt8>) -> Array<UInt32> {

--- a/Modules/WebSocket/Sources/WebSocket/SHA1.swift
+++ b/Modules/WebSocket/Sources/WebSocket/SHA1.swift
@@ -34,19 +34,19 @@ func reverseBytes(_ value: UInt32) -> UInt32 {
 
 func arrayOfBytes<T>(_ value: T, length: Int? = nil) -> [UInt8] {
     let totalBytes = length ?? MemoryLayout<T>.size
-    
+
     let valuePointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
     valuePointer.pointee = value
-    
+
     let bytesPointer = UnsafeMutablePointer<UInt8>(OpaquePointer(valuePointer))
     var bytes = Array<UInt8>(repeating: 0, count: totalBytes)
     for j in 0..<min(MemoryLayout<T>.size,totalBytes) {
         bytes[totalBytes - 1 - j] = (bytesPointer + j).pointee
     }
-    
+
     valuePointer.deinitialize()
     valuePointer.deallocate(capacity: 1)
-    
+
     return bytes
 }
 

--- a/Modules/WebSocket/Tests/LinuxMain.swift
+++ b/Modules/WebSocket/Tests/LinuxMain.swift
@@ -3,5 +3,6 @@ import XCTest
 
 XCTMain([
     testCase(FrameTests.allTests),
+    testCase(SHA1Tests.allTests),
     testCase(WebSocketTests.allTests),
 ])

--- a/Modules/WebSocket/Tests/WebSocketTests/SHA1Tests.swift
+++ b/Modules/WebSocket/Tests/WebSocketTests/SHA1Tests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import WebSocket
+
+class SHA1Tests: XCTestCase {
+
+    func testSHA1() {
+        let data = Array("sha1".utf8)
+        let hash = sha1(data)
+        
+        var hexString = ""
+        for byte in hash {
+            hexString += String(format: "%02x", UInt(byte))
+        }
+        
+        XCTAssert(hexString == "415ab40ae9b7cc4e66d6769cb2c08106e8293b48")
+    }
+
+}
+
+extension SHA1Tests {
+    public static var allTests: [(String, (SHA1Tests) -> () throws -> Void)] {
+        return [
+            ("testSHA1", testSHA1),
+        ]
+    }
+}

--- a/Modules/WebSocket/Tests/WebSocketTests/SHA1Tests.swift
+++ b/Modules/WebSocket/Tests/WebSocketTests/SHA1Tests.swift
@@ -1,18 +1,17 @@
 import XCTest
 @testable import WebSocket
 
-class SHA1Tests: XCTestCase {
-
+class SHA1Tests : XCTestCase {
     func testSHA1() {
         let data = Array("sha1".utf8)
         let hash = sha1(data)
-        
+
         var hexString = ""
         for byte in hash {
             hexString += String(format: "%02x", UInt(byte))
         }
-        
-        XCTAssert(hexString == "415ab40ae9b7cc4e66d6769cb2c08106e8293b48")
+
+        XCTAssertEqual(hexString, "415ab40ae9b7cc4e66d6769cb2c08106e8293b48")
     }
 
 }

--- a/Modules/WebSocket/Tests/WebSocketTests/SHA1Tests.swift
+++ b/Modules/WebSocket/Tests/WebSocketTests/SHA1Tests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import WebSocket
 
-class SHA1Tests : XCTestCase {
+public class SHA1Tests : XCTestCase {
     func testSHA1() {
         let data = Array("sha1".utf8)
         let hash = sha1(data)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -77,6 +77,7 @@ var testCases = [
 
     // WebSocket
     testCase(FrameTests.allTests),
+    testCase(SHA1Tests.allTests),
     testCase(WebSocketTests.allTests),
     // WebSocketClient
     testCase(WebSocketClientTests.allTests),


### PR DESCRIPTION
This fixes the SHA1 hash calculation and adds a unit test for it as described here: Zewo/Zewo#186
