### PR TITLE
[TrieRouteMatcher] Fix bug where paths with no components would return the head of the trie

### DIFF
--- a/Modules/HTTPServer/Sources/HTTPServer/Router/TrieRouteMatcher.swift
+++ b/Modules/HTTPServer/Sources/HTTPServer/Router/TrieRouteMatcher.swift
@@ -36,7 +36,7 @@ public struct TrieRouteMatcher {
 
         let matched = searchForRoute(
             head: routesTrie,
-            components: components.makeIterator(),
+            components: (components.isEmpty ? [""] : components).makeIterator(),
             parameters: &parameters
         )
 

--- a/Modules/HTTPServer/Sources/HTTPServer/Router/TrieRouteMatcher.swift
+++ b/Modules/HTTPServer/Sources/HTTPServer/Router/TrieRouteMatcher.swift
@@ -6,11 +6,8 @@ public struct TrieRouteMatcher {
         self.routes = routes
 
         for route in routes {
-            // break into components
-            let components = route.path.split(separator: "/")
-
-            // insert components into trie with route being the ending payload
-            routesTrie.insert(components, payload: route)
+            // insert path components into trie with route being the ending payload
+            routesTrie.insert(route.path.pathComponents, payload: route)
         }
 
         // ensure parameter paths are processed later than static paths
@@ -30,13 +27,12 @@ public struct TrieRouteMatcher {
     }
 
     public func match(_ request: Request) -> Route? {
-        let path = request.path!
-        let components = path.unicodeScalars.split(separator: "/").map(String.init)
+        let components = request.path!.pathComponents
         var parameters: [String: String] = [:]
 
         let matched = searchForRoute(
             head: routesTrie,
-            components: (components.isEmpty ? [""] : components).makeIterator(),
+            components: components.makeIterator(),
             parameters: &parameters
         )
 
@@ -129,5 +125,12 @@ extension Dictionary {
         }
         
         return dictionary
+    }
+}
+
+extension String {
+    fileprivate var pathComponents: [String] {
+        let components = unicodeScalars.split(separator: "/").map(String.init)
+        return (components.isEmpty ? [""] : components)
     }
 }

--- a/Modules/HTTPServer/Sources/HTTPServer/Router/TrieRouteMatcher.swift
+++ b/Modules/HTTPServer/Sources/HTTPServer/Router/TrieRouteMatcher.swift
@@ -116,18 +116,6 @@ public struct TrieRouteMatcher {
     }
 }
 
-extension Dictionary {
-    func mapValues<T>(_ transform: (Value) -> T) -> [Key: T] {
-        var dictionary: [Key: T] = [:]
-        
-        for (key, value) in self {
-            dictionary[key] = transform(value)
-        }
-        
-        return dictionary
-    }
-}
-
 extension String {
     fileprivate var pathComponents: [String] {
         let components = unicodeScalars.split(separator: "/").map(String.init)

--- a/Modules/HTTPServer/Tests/HTTPServerTests/Router/TrieRouteMatcherTests.swift
+++ b/Modules/HTTPServer/Tests/HTTPServerTests/Router/TrieRouteMatcherTests.swift
@@ -185,6 +185,7 @@ public class TrieRouteMatcherTests : XCTestCase {
             return buffer == expectedResponse.buffer
         }
 
+        XCTAssert(route("/", expectedResponse: "wild"))
         XCTAssert(route("/a/s/d/f", expectedResponse: "wild"))
         XCTAssert(route("/hello/asdf", expectedResponse: "hello wild"))
         XCTAssert(route("/hello/dan", expectedResponse: "hello dan"))


### PR DESCRIPTION
Added a test case that catches this as well.
