### PR TITLE
[Resource] Place custom routes after inherited routes to allow proper overriding

### DIFF
--- a/Modules/HTTPServer/Sources/HTTPServer/Resource/Resource.swift
+++ b/Modules/HTTPServer/Sources/HTTPServer/Resource/Resource.swift
@@ -73,12 +73,12 @@ public extension Resource {
 extension Resource {
     public var router: BasicRouter {
         let routes = ResourceRoutes(staticFilesPath: staticFilesPath)
-        custom(routes: routes)
         routes.list(respond: list)
         routes.create(respond: create)
         routes.detail(respond: detail)
         routes.update(respond: update)
         routes.destroy(respond: destroy)
+        custom(routes: routes)
         return BasicRouter(middleware: [RecoveryMiddleware(recover)] + middleware, routes: routes)
     }
 }


### PR DESCRIPTION
This allows consumers to override routes. For example, a user might want to have a `POST /` without requiring a body (this is the only way to do so).
