### PR TITLE
[Mapper] Remove IndexPath typealias to avoid naming conflicts with Foundation

### DIFF
--- a/Modules/Mapper/Sources/Mapper/IndexPath.swift
+++ b/Modules/Mapper/Sources/Mapper/IndexPath.swift
@@ -3,8 +3,6 @@ public enum IndexPathValue {
     case key(String)
 }
 
-public typealias IndexPath = [IndexPathValue]
-
 /// Can be represented as `IndexPathValue`.
 public protocol IndexPathElement {
     var indexPathValue: IndexPathValue { get }


### PR DESCRIPTION
This PR removes `typealias IndexPath = [IndexPathValue]` because it clashes with `Foundation` `IndexPath` (previously `NSIndexPath`). Because I find **Mapper** to be very useful in iOS/macOS/tvOS/watchOS development, I think this is necessary.
