### PR TITLE
Added accessible timeouts to HTTPServer and WebSockets

### DIFF
--- a/Modules/HTTPServer/Sources/HTTPServer/Server/Server.swift
+++ b/Modules/HTTPServer/Sources/HTTPServer/Server/Server.swift
@@ -113,6 +113,7 @@ extension Server {
                 try serializer.serialize(response, deadline: .never)
 
                 if let error = unrecoveredError {
+                    stream.close()
                     throw error
                 }
             }

--- a/Modules/HTTPServer/Sources/HTTPServer/Server/Server.swift
+++ b/Modules/HTTPServer/Sources/HTTPServer/Server/Server.swift
@@ -61,21 +61,21 @@ func retry(times: Int, waiting duration: Double, work: (Void) throws -> Void) th
 }
 
 extension Server {
-    public func start() throws {
+  public func start(_ retryTimes: Int = 10, _ retryWait: Double = 5.seconds, _ readDeadline: Double = 30.seconds.fromNow(), _ serializeDeadline: Double = 5.minutes.fromNow()) throws {
         printHeader()
-        try retry(times: 10, waiting: 5.seconds) {
+        try retry(times: retryTimes, waiting: retryWait) {
             while true {
                 let stream = try tcpHost.accept(deadline: .never)
-                co { do { try self.process(stream: stream) } catch { self.failure(error) } }
+                co { do { try self.process(stream: stream, readDeadline, serializeDeadline) } catch { self.failure(error) } }
             }
         }
     }
 
-    public func startInBackground() {
-        co { do { try self.start() } catch { self.failure(error) } }
+  public func startInBackground(_ retryTimes: Int = 10, _ retryWait: Double = 5.seconds, _ readDeadline: Double = 30.seconds.fromNow(), _ serializeDeadline: Double = 5.minutes.fromNow()) {
+        co { do { try self.start(retryTimes, retryWait, readDeadline, serializeDeadline) } catch { self.failure(error) } }
     }
 
-    public func process(stream: Stream) throws {
+  public func process(stream: Stream, _ readDeadline: Double = 30.seconds.fromNow(), _ serializeDeadline: Double = 5.minutes.fromNow()) throws {
         let buffer = UnsafeMutableBufferPointer<Byte>(capacity: bufferSize)
         defer { buffer.deallocate(capacity: bufferSize) }
 
@@ -84,14 +84,12 @@ extension Server {
 
         while !stream.closed {
             do {
-                // TODO: Add timeout parameter
-                let bytesRead = try stream.read(into: buffer, deadline: 30.seconds.fromNow())
+                let bytesRead = try stream.read(into: buffer, deadline: readDeadline)
                 
                 for message in try parser.parse(bytesRead) {
                     let request = message as! Request
                     let response = try middleware.chain(to: responder).respond(to: request)
-                    // TODO: Add timeout parameter
-                    try serializer.serialize(response, deadline: 5.minutes.fromNow())
+                    try serializer.serialize(response, deadline: serializeDeadline)
                     
                     if let upgrade = response.upgradeConnection {
                         try upgrade(request, stream)
@@ -129,7 +127,7 @@ extension Server {
     }
 
     public static func log(error: Error) -> Void {
-        print("Zewo/HTTPServer error: \(error)")
+        print("Zewo/HTTPServer Error: \(error)")
     }
 
     public func printHeader() {

--- a/Modules/HTTPServer/Sources/HTTPServer/Server/Server.swift
+++ b/Modules/HTTPServer/Sources/HTTPServer/Server/Server.swift
@@ -129,7 +129,7 @@ extension Server {
     }
 
     public static func log(error: Error) -> Void {
-        print("Error: \(error)")
+        print("Zewo/HTTPServer error: \(error)")
     }
 
     public func printHeader() {

--- a/Modules/WebSocket/Sources/WebSocket/WebSocket.swift
+++ b/Modules/WebSocket/Sources/WebSocket/WebSocket.swift
@@ -85,19 +85,19 @@ public final class WebSocket {
         return closeEventEmitter.addListener(listen: listen)
     }
 
-    public func send(_ string: String) throws {
-        try send(.text, data: Buffer(string))
+    public func send(_ string: String, _ writeDeadline: Double = 5.seconds.fromNow(), _ flushDeadline: Double = 5.seconds.fromNow()) throws {
+        try send(.text, data: Buffer(string), writeDeadline, flushDeadline)
     }
 
-    public func send(_ data: Buffer) throws {
-        try send(.binary, data: data)
+    public func send(_ data: Buffer, _ writeDeadline: Double = 5.seconds.fromNow(), _ flushDeadline: Double = 5.seconds.fromNow()) throws {
+        try send(.binary, data: data, writeDeadline, flushDeadline)
     }
 
-    public func send(_ convertible: BufferConvertible) throws {
-        try send(.binary, data: convertible.buffer)
+    public func send(_ convertible: BufferConvertible, _ writeDeadline: Double = 5.seconds.fromNow(), _ flushDeadline: Double = 5.seconds.fromNow()) throws {
+        try send(.binary, data: convertible.buffer, writeDeadline, flushDeadline)
     }
 
-    public func close(_ code: CloseCode = .normal, reason: String? = nil) throws {
+    public func close(_ code: CloseCode = .normal, reason: String? = nil, _ writeDeadline: Double = 5.seconds.fromNow(), _ flushDeadline: Double = 5.seconds.fromNow()) throws {
         if closeState == .serverClose {
             return
         }
@@ -116,27 +116,27 @@ public final class WebSocket {
             stream.close()
         }
 
-        try send(.close, data: data)
+        try send(.close, data: data, writeDeadline, flushDeadline)
 
         if closeState == .clientClose {
             stream.close()
         }
     }
 
-    public func ping(_ data: Buffer = Buffer()) throws {
-        try send(.ping, data: data)
+    public func ping(_ data: Buffer = Buffer(), _ writeDeadline: Double = 5.seconds.fromNow(), _ flushDeadline: Double = 5.seconds.fromNow()) throws {
+        try send(.ping, data: data, writeDeadline, flushDeadline)
     }
 
-    public func ping(_ convertible: BufferConvertible) throws {
-        try send(.ping, data: convertible.buffer)
+    public func ping(_ convertible: BufferConvertible, _ writeDeadline: Double = 5.seconds.fromNow(), _ flushDeadline: Double = 5.seconds.fromNow()) throws {
+        try send(.ping, data: convertible.buffer, writeDeadline, flushDeadline)
     }
 
-    public func pong(_ data: Buffer = Buffer()) throws {
-        try send(.pong, data: data)
+    public func pong(_ data: Buffer = Buffer(), _ writeDeadline: Double = 5.seconds.fromNow(), _ flushDeadline: Double = 5.seconds.fromNow()) throws {
+        try send(.pong, data: data, writeDeadline, flushDeadline)
     }
 
-    public func pong(_ convertible: BufferConvertible) throws {
-        try send(.pong, data: convertible.buffer)
+    public func pong(_ convertible: BufferConvertible, _ writeDeadline: Double = 5.seconds.fromNow(), _ flushDeadline: Double = 5.seconds.fromNow()) throws {
+        try send(.pong, data: convertible.buffer, writeDeadline, flushDeadline)
     }
 
     public func start() throws {
@@ -322,7 +322,7 @@ public final class WebSocket {
         }
     }
 
-    fileprivate func send(_ opCode: Frame.OpCode, data: Buffer) throws {
+  fileprivate func send(_ opCode: Frame.OpCode, data: Buffer, _ writeDeadline: Double , _ flushDeadline: Double) throws {
         let maskKey: Buffer
         if mode == .client {
             maskKey = try Buffer(randomBytes: 4)
@@ -331,8 +331,8 @@ public final class WebSocket {
         }
         let frame = Frame(opCode: opCode, data: data, maskKey: maskKey)
         let data = frame.data
-        try stream.write(data, deadline: 5.seconds.fromNow())
-        try stream.flush(deadline: 5.seconds.fromNow())
+        try stream.write(data, deadline: writeDeadline)
+        try stream.flush(deadline: flushDeadline)
     }
 
     public static func accept(_ key: String) -> String? {


### PR DESCRIPTION
Thanks for contributing! For small pull requests that fix things like typos, using the following template is overkill. However, if you're fixing a significant bug or implementing a feature, please do use it as it will speed up the whole process immensely.

--------------------------------------------------------------------------------

# Summary

WebSocket:
- added parameters in the public functions to allow to set the stream write and stream flush timeouts.

HTTPServer:
- fixed bug where stream was left open when an unrecovered error occurred
- updated the error message to specific that the error comes for Zewo/HTTPServer
- added parameters in the public functions to allow to set the number of retrie, the waiting time between retries, and stream timeouts for reading and serialising.