### PR TITLE
Introduced LoggerManager factory

### DIFF
--- a/Modules/Axis/Sources/Axis/Log/Log.swift
+++ b/Modules/Axis/Sources/Axis/Log/Log.swift
@@ -160,7 +160,7 @@ extension Logger {
     }
 }
 
-class Weak<T: AnyObject> {
+final class Weak<T: AnyObject> {
     weak var value : T?
     init (value: T) {
         self.value = value

--- a/Modules/Axis/Sources/Axis/Log/Log.swift
+++ b/Modules/Axis/Sources/Axis/Log/Log.swift
@@ -159,3 +159,31 @@ extension Logger {
         return Logger.logTimeFormatter.string(from: Date())
     }
 }
+
+class Weak<T: AnyObject> {
+    weak var value : T?
+    init (value: T) {
+        self.value = value
+    }
+}
+
+public final class LoggerManager {
+
+    static var appenders: [Appender] = []
+
+    static var loggers: [String: Weak<Logger>] = [:]
+
+    public class func configure(appenders: [Appender]) {
+        self.appenders = appenders
+    }
+
+    public static func getLogger(name: String) -> Logger {
+        if let logger = LoggerManager.loggers[name] , logger.value != nil {
+            return logger.value!
+        } else {
+            let logger = Logger(name: name, appenders: LoggerManager.appenders)
+            loggers[name] = Weak(value: logger)
+            return loggers[name]!.value!
+        }
+    }
+}

--- a/Modules/Axis/Tests/AxisTests/Logger/LoggerTests.swift
+++ b/Modules/Axis/Tests/AxisTests/Logger/LoggerTests.swift
@@ -2,6 +2,37 @@ import XCTest
 import Foundation
 @testable import Axis
 
+var executedAppender: Bool = false
+
+class FakeAppender: Appender {
+    public func append(event: Logger.Event) {
+        executedAppender = true
+    }
+
+    public var name: String = "fake"
+    public var levels: Logger.Level = []
+}
+
+
+public class LoggerManagerTests : XCTestCase {
+
+    func testConfigure() {
+        LoggerManager.loggers = [:]
+        LoggerManager.configure(appenders: [FakeAppender()])
+        let logger = LoggerManager.getLogger(name: "test") // could be freed when reference = 0
+        logger.debug("test")
+        XCTAssert(executedAppender)
+    }
+
+    func testGetLogger() {
+        LoggerManager.loggers = [:]
+        LoggerManager.configure(appenders: [])
+        let logger = LoggerManager.getLogger(name: "test")
+        let logger2 = LoggerManager.getLogger(name: "test")
+        XCTAssert(logger === logger2)
+    }
+}
+
 public class LoggerTests : XCTestCase {
     func testLogger() throws {
         let appender = StandardOutputAppender()
@@ -61,6 +92,15 @@ extension LoggerTests {
         return [
             ("testLogger", testLogger),
             ("testDateFormatter", testDateFormatter)
+        ]
+    }
+}
+
+extension LoggerManagerTests {
+    public static var allTests: [(String, (LoggerManagerTests) -> () throws -> Void)] {
+        return [
+            ("testConfigure", testConfigure),
+            ("testGetLogger", testGetLogger)
         ]
     }
 }


### PR DESCRIPTION
# LoggerManager

Logger class is a great way to log, but there is currently no way to inject third party appenders to all Logger() instances. Therefore i propose new way to use logging


    LoggerManager.configure(appenders: [MyVeryOwnUdpAppender(levels: [.debug])])

Then, across all libs/apps use this simple construction without specyfing appenders all the time.

    let logger = LoggerManager.getLogger("main")
    logger.debug("Hello")

# Design decisions

I used Weak storage to allow garbage collection of unused loggers, similar to java's behavior (http://docs.oracle.com/javase/6/docs/api/java/util/logging/Logger.html)

# Why

Separation of concerns. We could specify logger plugins outside of libraries.