### PR TITLE
Remove spurious tcpStream.open in ssl mode

### DIFF
--- a/Modules/TCP/Sources/TCP/TCPTLSStream.swift
+++ b/Modules/TCP/Sources/TCP/TCPTLSStream.swift
@@ -15,7 +15,6 @@ public struct TCPTLSStream : Stream {
     }
 
     public func open(deadline: Double) throws {
-        try tcpStream.open(deadline: deadline)
         try sslStream.open(deadline: deadline)
     }
 


### PR DESCRIPTION
It was unneded here since we allocate it with sslStream
