### PR TITLE
Mapper string representable enum fix

### DIFF
--- a/Modules/Axis/Sources/Axis/Map/Map+Mapper.swift
+++ b/Modules/Axis/Sources/Axis/Map/Map+Mapper.swift
@@ -12,7 +12,7 @@ extension Map : InMap {
     }
     
     public func get<T>() -> T? {
-        return self.get()
+        return try? self.get()
     }
     
 }

--- a/Modules/Axis/Tests/AxisTests/Map/MapTests.swift
+++ b/Modules/Axis/Tests/AxisTests/Map/MapTests.swift
@@ -800,6 +800,37 @@ public class MapTests : XCTestCase {
         let fuuDictionaryB: [String: Baz] = [:]
         XCTAssertEqual(try fuuDictionaryB.asMap(), [:])
     }
+
+    
+    func testMapperWithEnumInStruct() throws {
+        enum MyEnum: String {
+            case one
+        }
+        
+        struct SomeStruct: InMappable, OutMappable {
+            let oneValue: MyEnum
+            
+            enum MappingKeys : String, IndexPathElement {
+                case oneValue
+            }
+            
+            init<Source : InMap>(mapper: InMapper<Source, MappingKeys>) throws {
+                self.oneValue = try mapper.map(from: .oneValue)
+            }
+            
+            func outMap<Destination : OutMap>(mapper: inout OutMapper<Destination, MappingKeys>) throws {
+                try mapper.map(self.oneValue, to: .oneValue)
+            }
+            
+        }
+        
+        let str = "{\"oneValue\":\"one\"}"
+        let map = try JSONMapParser.parse(str)
+        let someStruct = try SomeStruct(from: map)
+        
+        XCTAssertTrue(someStruct.oneValue == .one)
+    }
+
     
 }
 
@@ -813,6 +844,8 @@ extension MapTests {
            ("testIndexPath", testIndexPath),
            ("testMapInitializable", testMapInitializable),
            ("testMapRepresentable", testMapRepresentable),
+           ("testEnumMapInitializable", testEnumMapInitializable),
+           ("testEnumMapRepresentable", testEnumMapRepresentable),
         ]
     }
 }

--- a/Modules/Axis/Tests/AxisTests/Map/MapTests.swift
+++ b/Modules/Axis/Tests/AxisTests/Map/MapTests.swift
@@ -844,8 +844,7 @@ extension MapTests {
            ("testIndexPath", testIndexPath),
            ("testMapInitializable", testMapInitializable),
            ("testMapRepresentable", testMapRepresentable),
-           ("testEnumMapInitializable", testEnumMapInitializable),
-           ("testEnumMapRepresentable", testEnumMapRepresentable),
+           ("testMapperWithEnumInStruct", testMapperWithEnumInStruct),
         ]
     }
 }


### PR DESCRIPTION
Fix Map+Mapper extensions for string representable enum variables.

The fix is based on the tests provided in the Zewo/Mapper repository (https://github.com/Zewo/Mapper/blob/master/Tests/MapperTests/Map.swift#L827).

See provided test.