### PR TITLE
Added @testable for Zewo import

### DIFF
--- a/Tests/HTTPTests/ServerTest.swift
+++ b/Tests/HTTPTests/ServerTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import Media
 import HTTP
 import Venice
-import Zewo
+@testable import Zewo
 
 class ServerTest: XCTestCase {
     func testServer() throws {


### PR DESCRIPTION
Add @testable for  `import Zewo` to fix `./Zewo/Tests/HTTPTests/ServerTest.swift` issue.